### PR TITLE
Simple Query Benchmark (SQB) to test hash table

### DIFF
--- a/src/simulators/hashmap.py
+++ b/src/simulators/hashmap.py
@@ -189,7 +189,7 @@ class GenericHashTableBucket(Generic[KV_TYPE]):
         Attempt to locate the provided key in this bucket. If found, will return a hit of true and the index of the hit
         within this bucket. If not found, will return a hit of false and the index of -1.
         """
-        for index, kv in enumerate(self.kvs):
+        for index, kv in zip(range(self.count), self.kvs):
             if key == kv.key:
                 return True, index
         return False, -1
@@ -232,6 +232,8 @@ class GenericHashMapObject(Generic[KV_TYPE, BUCKET_TYPE]):
         self._bucket_capacity = bucket_capacity
         self._kv_generator = kv_generator
         self._bucket_generator = bucket_generator
+
+        assert initial_buckets <= maximum_buckets, "Initial number of buckets is greater than the maximum capacity"
 
         if buckets:
             assert len(buckets) <= maximum_buckets, "Provided buckets are larger than the maximum capacity"

--- a/studies/simple_query_benchmark/README.md
+++ b/studies/simple_query_benchmark/README.md
@@ -1,0 +1,57 @@
+# Simple Query Benchmark (SQB)
+
+## Schema
+
+### A
+
+| Column | Domain                                  |
+| ------ | --------------------------------------- |
+| a_k    | $\left[ 0, \lvert A \rvert - 1 \right]$ |
+| a_b_k  | $\left[ 0, \lvert B \rvert - 1 \right]$ |
+| a_10   | $\left[ 0, 9 \right]$                   |
+| a_100  | $\left[ 0, 99 \right]$                  |
+
+### B
+
+| Column | Domain                                  |
+| ------ | --------------------------------------- |
+| b_k    | $\left[ 0, \lvert B \rvert - 1 \right]$ |
+| b_10   | $\left[ 0, 9 \right]$                   |
+| b_100  | $\left[ 0, 99 \right]$                  |
+
+## Queries
+
+### SQ1
+
+```sql
+SELECT SUM(a_10)
+FROM A;
+```
+
+### SQ2
+
+```sql
+SELECT SUM(a_10)
+FROM A
+WHERE a_100 < ?;
+```
+
+### SQ3
+
+```sql
+SELECT SUM(a_10)
+FROM A, B
+WHERE a_b_k = b_k
+  AND b_100 < ?;
+```
+
+### SQ4
+
+```sql
+SELECT b_10, SUM(a_10)
+FROM A, B
+WHERE a_b_k = b_k
+  AND b_100 < ?
+GROUP BY b_10
+ORDER BY b_10;
+```

--- a/studies/simple_query_benchmark/blimp_hash_table.py
+++ b/studies/simple_query_benchmark/blimp_hash_table.py
@@ -1,0 +1,37 @@
+from src.simulators.hashmap import *
+
+
+# Define 32bit KV pairs
+class HashTable32KV(GenericHashTableKV):
+    """Defines the pythonic structure of a 32-bit key 32-bit value object"""
+    _KEY_SIZE_BYTES = 4
+    _VALUE_SIZE_BYTES = 4
+
+
+# Define a bucket using 4 byte count/next bucket values, with UINT32_MAX as the null value
+class BlimpHashTableBucket(GenericHashTableBucket[HashTable32KV]):
+    _NULL_VALUE = 2 ** 32 - 1
+    _ACTIVE_COUNT_SIZE_BYTES = 4
+    _NEXT_BUCKET_SIZE_BYTES = 4
+
+
+# Generate a templated hash table that utilizes 32bit KVs and a simple hash; this is our custom table for BLIMP
+class BlimpSimpleHashTable(GenericHashMapObject[HashTable32KV, BlimpHashTableBucket]):
+    bucket_capacity = 15
+
+    def __init__(self, initial_buckets: int, maximum_buckets: int):
+        super().__init__(
+            initial_buckets,
+            maximum_buckets,
+            bucket_capacity=self.bucket_capacity,
+            kv_generator=HashTable32KV,
+            bucket_generator=BlimpHashTableBucket
+        )
+
+        assert (initial_buckets & (initial_buckets - 1) == 0) and initial_buckets != 0, \
+            "initial_buckets must be a power of 2"
+        self._mask = initial_buckets - 1
+
+    def _hash(self, key) -> int:
+        """Hash the key and return an index into buckets"""
+        return (3634946921 * key + 2096170329) & self._mask

--- a/studies/simple_query_benchmark/database.py
+++ b/studies/simple_query_benchmark/database.py
@@ -1,0 +1,18 @@
+import random
+
+
+class SQBDatabase:
+    def __init__(self, n_a, n_b):
+        random.seed(0)  # Initialize the random generator with a seed to ensure reproducibility.
+        self._a = [(i, random.randint(0, n_b - 1), random.randint(0, 9), random.randint(0, 99)) for i in range(n_a)]
+        self._b = [(i, random.randint(0, 9), random.randint(0, 99)) for i in range(n_b)]
+        random.shuffle(self._a)
+        random.shuffle(self._b)
+
+    @property
+    def a(self):
+        return self._a
+
+    @property
+    def b(self):
+        return self._b

--- a/studies/simple_query_benchmark/sq3.py
+++ b/studies/simple_query_benchmark/sq3.py
@@ -1,0 +1,41 @@
+import math
+
+from blimp_hash_table import *
+from database import *
+
+n_a = 10 ** 3  # Number of rows in table A.
+n_b = 10 ** 3  # Number of rows in table B.
+sel = 10  # Selectivity (percentage of rows selected).
+lf = 0.5  # Load factor of the hash table (number of rows / number of slots).
+
+# Compute the number of initial buckets from the number of rows, selectivity, and load factor. Round up to the next
+# power of two.
+initial_buckets = math.ceil(n_b * sel / 100 / lf / BlimpSimpleHashTable.bucket_capacity)
+initial_buckets = 1 if initial_buckets == 0 else 2 ** math.ceil(math.log2(initial_buckets))
+
+# Define our hash table.
+ht = BlimpSimpleHashTable(
+    initial_buckets=initial_buckets,
+    maximum_buckets=2 ** 24 // 128,  # Limit ourselves to 16MB worth of 128B buckets
+)
+
+# Generate the data.
+db = SQBDatabase(n_a, n_b)
+
+# Build the hash table. SQ3 is a semijoin, so we need only the keys from B in the hash table, none of the values.
+# Eventually, we can optimize this by building a hash set, rather than a hash table. For now, we insert an arbitrary
+# integer (0) into the hash table as the value.
+for (b_k, _, b_100) in db.b:
+    if b_100 < sel:
+        ht.insert(b_k, 0)
+
+# Save the hash table.
+ht.save('./sq3.json')
+
+# Probe the hash table and compute the result.
+result = sum(a_10 for (_, a_b_k, a_10, _) in db.a if ht.fetch(a_b_k) is not None)
+
+# Compare the result to a reference result.
+reference_set = {b_k for (b_k, _, b_100) in db.b if b_100 < sel}
+reference_result = sum(a_10 for (_, a_b_k, a_10, _) in db.a if a_b_k in reference_set)
+assert result == reference_result, "result does not equal the reference result"

--- a/studies/simple_query_benchmark/sq4.py
+++ b/studies/simple_query_benchmark/sq4.py
@@ -1,0 +1,50 @@
+import math
+from collections import defaultdict
+
+from blimp_hash_table import *
+from database import *
+
+n_a = 10 ** 3  # Number of rows in table A.
+n_b = 10 ** 3  # Number of rows in table B.
+sel = 10  # Selectivity (percentage of rows selected).
+lf = 0.5  # Load factor of the hash table (number of rows / number of slots).
+
+# Compute the number of initial buckets from the number of rows, selectivity, and load factor. Round up to the next
+# power of two.
+initial_buckets = math.ceil(n_b * sel / 100 / lf / BlimpSimpleHashTable.bucket_capacity)
+initial_buckets = 1 if initial_buckets == 0 else 2 ** math.ceil(math.log2(initial_buckets))
+
+# Define our hash table.
+ht = BlimpSimpleHashTable(
+    initial_buckets=initial_buckets,
+    maximum_buckets=2 ** 24 // 128,  # Limit ourselves to 16MB worth of 128B buckets
+)
+
+# Generate the data.
+db = SQBDatabase(n_a, n_b)
+
+# Build the hash table.
+for (b_k, b_10, b_100) in db.b:
+    if b_100 < sel:
+        ht.insert(b_k, b_10)
+
+# Save the hash table.
+ht.save('./sq4.json')
+
+# Probe the hash table and compute the result.
+result_dict = defaultdict(int)
+for (_, a_b_k, a_10, _) in db.a:
+    kv = ht.fetch(a_b_k)
+    if kv is not None:
+        result_dict[kv.val] += a_10
+result = list(sorted(result_dict.items()))
+
+# Compare the result to a reference result.
+reference_dict = {b_k: b_10 for (b_k, b_10, b_100) in db.b if b_100 < sel}
+reference_result_dict = defaultdict(int)
+for (_, a_b_k, a_10, _) in db.a:
+    value = reference_dict.get(a_b_k)
+    if value is not None:
+        reference_result_dict[value] += a_10
+reference_result = list(sorted(reference_result_dict.items()))
+assert result == reference_result, "result does not equal the reference result"


### PR DESCRIPTION
This PR introduces the Simple Query Benchmark (we can call it SQB) consisting of four very simple queries to test out basic functionality of our kernels. See `studies/simple_query_benchmark/README.md` for the description of the benchmark. We can add more queries to the benchmark as needed in the future.

I also provide implementations of SQ3 and SQ4, which are the join queries, to test out the hash table implementation. See `studies/simple_query_benchmark/sq3.py` and `studies/simple_query_benchmark/sq4.py`.

Finally, I fixed a small bug and added an assert check in `src/simulators/hashmap.py`.

Feel free to refactor this code however you'd like.